### PR TITLE
Clean up / add character-frame ilvl display, and pref for same

### DIFF
--- a/Fizzle.toc
+++ b/Fizzle.toc
@@ -1,12 +1,12 @@
 #@retail@
-## Interface: 80300
+## Interface: 90002
 #@end-retail@
 #@non-retail@
 # ## Interface: 11303
 #@end-non-retail@
 ## Title: Fizzle
 ## Author: phyber
-## Notes: Show item durability and quality in the character frame.
+## Notes: Show item ilevel, durability, and quality in the character frame.
 ## Notes-zhTW: 在角色視窗顯示耐久度。
 ## Notes-zhCN: 在人物装备栏中显示物品品质与耐久度。
 ## Version: @project-version@


### PR DESCRIPTION
This commit finishes the existing work to show ilevel on items in the
character frame, adding an appropriate option checkbox to the prefs.

Along the way it does a little tidying and clarifying of the "items"
versus "nditems" contents, and scoops out some duplicate logic into
separate, more generic functions.

Also it bumps the TOC to 90002 and makes the appropriate code changes to
the detection of Classic vs Retail.